### PR TITLE
Move user groups in nav and link to it from get involved page

### DIFF
--- a/template/pages/get_involved.html
+++ b/template/pages/get_involved.html
@@ -23,8 +23,8 @@
           Through your membership to PgUS, you influence the growth and education of PostgreSQL. Memberships are $25 for professionals and $10 for students. You'll receive our monthly newsletter about what's happening at PgUS and you'll be able to vote in the annual PgUS elections. <a href="https://postgresql.us/membership">Join today!</a>
         </p>
         <br>
-        <h3>Attend a Postgres User Group</h3>
-        <p>PgUS sponsors more than 20 meetups across North America and across the world. <a href="https://www.meetup.com/pro/postgresql/">Find a meeting near you</a>.</p>
+        <h3>Attend a User Group</h3>
+        <p>PgUS sponsors more than 20 Postgres user groups around the world. Learn more about <a href="/usergroups">starting a new user group</a>, or <a href="https://www.meetup.com/pro/postgresql/">find an existing user group near you</a>.</p>
         <br>
         <h3>Sponsorships</h3>
         <p>

--- a/template/pieces/navigation.html
+++ b/template/pieces/navigation.html
@@ -46,14 +46,24 @@
               </li>
             </ul>
           </li>
+          <li class="cs-li cs-dropdown">
+            <span class="cs-li-link">
+              Get Involved
+              <img class="cs-drop-icon" src="/media/pgus/images/dropdown-arrow.svg"
+                alt="dropdown icon" width="15" height="15" decoding="async" aria-hidden="true">
+            </span>
+            <ul class="cs-drop-ul">
+              <li class="cs-drop-li">
+                <a href="/get_involved" class="cs-li-link cs-drop-link">Get Involved</a>
+              </li>
+              <li class="cs-drop-li">
+                <a href="/usergroups" class="cs-li-link cs-drop-link">User Groups</a>
+              </li>
+            </ul>
+          </li>
           <li class="cs-li">
             <a href="/diversity" class="cs-li-link cs-active">
               Diversity
-            </a>
-          </li>
-          <li class="cs-li">
-            <a href="/get_involved" class="cs-li-link cs-active">
-              Get Involved
             </a>
           </li>
           <li class="cs-li">


### PR DESCRIPTION
1. Changed the nav to have a second drop down section, to move the User Group page in there. I don't love the double "Get Involved" but didn't know what else to call it, so left it as that for now
2. Changed the Get Involved page text to link to the User Group page

Changes requested by Elizabeth, feedback before committing welcome

![changes](https://github.com/user-attachments/assets/89ad7efe-49f5-4fc6-bbaa-1b99cce484bd)
